### PR TITLE
Remove Matrix Build

### DIFF
--- a/.github/workflows/distribution-build.yaml
+++ b/.github/workflows/distribution-build.yaml
@@ -11,10 +11,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: [linux/arm64, linux/amd64]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -31,7 +27,7 @@ jobs:
           context: .
           file: ./docker/Dockerfile.prod
           push: true
-          platforms: ${{ matrix.platform }}
+          platforms: linux/arm64,linux/amd64
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/distribution:latest
           build-args: |
             APPLICATION=distribution

--- a/.github/workflows/notification-build.yaml
+++ b/.github/workflows/notification-build.yaml
@@ -11,10 +11,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: [linux/arm64, linux/amd64]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -31,7 +27,7 @@ jobs:
           context: .
           file: ./docker/Dockerfile.prod
           push: true
-          platforms: ${{ matrix.platform }}
+          platforms: linux/arm64,linux/amd64
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/notification:latest
           build-args: |
             APPLICATION=notification


### PR DESCRIPTION
## Summary
Remove matrix builds to avoid needing to merge manifests for multi-architecture support.